### PR TITLE
Fixes for module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,9 +20,11 @@ class couchdb (
 	}
 	
 	Exec["packager-update"] -> Package[$::couchdb::params::packages] -> Exec["clone"]
-	
-	package { $::couchdb::params::packages:
-		ensure	=> 'installed',
+
+	$::couchdb::params::packages.each |String $pkg|{
+        	if !defined(Package[$pkg]) {
+			package { $pkg: ensure	=> 'installed' }
+		}
 	}
 	
 	validate_bool($manage_group)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class couchdb::params {
 				'zlib-devel',
 				'openssl-devel',
 				'rubygem-rake',
-				'ruby-rdoc',
+				'rubygem-rdoc',
 				'help2man',
 				'texinfo'
 			]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class couchdb::params {
 				'texinfo'
 			]
 	$otp_options = "erl_checkout=\"tags/OTP-17.1\""
-	if $::operatingsystemmajrelease > 5 {
+	if 0 + $::operatingsystemmajrelease > 5 {
 		$otp_compability_options = "erl_checkout=\"tags/OTP_R14B04\" erl_cflags=\"-DOPENSSL_NO_EC=1\""
 	} else {
 		$otp_compability_options = "erl_checkout=\"tags/OTP_R14B04\""

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,9 @@ class couchdb::params {
   }
   
   $src_dir	= '/usr/local/src/couchdb'
-  $git_rep			= '-b ssl-ec git://github.com/zpetr/build-couchdb.git'
+  $git_rep			= '-b ssl-ec https://github.com/zpetr/build-couchdb.git'
   $git_rep_recursive = false
-  $couchdb_git		= 'git://git.apache.org/couchdb.git'
+  $couchdb_git		= 'https://git.apache.org/couchdb.git'
 
   if $::osfamily == 'RedHat' or $::operatingsystem == 'amazon' {
     $user                 = 'couchdb'


### PR DESCRIPTION
Two fixes:

1. Puppet 4.0 throws an error 'A String is not comparable to a non String' for comparing ::operatingsystemmajrelease to an integer. 

2. There are potential package conflicts with other modules.  